### PR TITLE
Add virtual binder fields generation with HeaderGroup support

### DIFF
--- a/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Descriptions/Classes.Aspid.cs
+++ b/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Descriptions/Classes.Aspid.cs
@@ -18,6 +18,20 @@ public static class Classes
     public static readonly TypeText ViewBinder =
         new (nameof(ViewBinder), Namespaces.Aspid_MVVM);
     #endregion
+
+    #region Headers
+    public static readonly AttributeText HeaderAttribute =
+        new(nameof(HeaderAttribute), "UnityEngine");
+       
+    public static readonly AttributeText HeaderGroupAttribute =
+        new (nameof(HeaderGroupAttribute), Namespaces.Aspid_MVVM);
+
+    public static readonly AttributeText HeaderGroupStartAttribute =
+        new (nameof(HeaderGroupStartAttribute), Namespaces.Aspid_MVVM);
+    
+    public static readonly AttributeText HeaderGroupEndAttribute = 
+        new (nameof(HeaderGroupEndAttribute), Namespaces.Aspid_MVVM);
+    #endregion
     
     #region Binders
     public static readonly TypeText BindMode =
@@ -33,7 +47,7 @@ public static class Classes
         new(nameof(IReverseBinder), Namespaces.Aspid_MVVM);
     
     public static readonly TypeText MonoBinder =
-        new(nameof(MonoBinder), Namespaces.Aspid_MVVM_UNITY);
+        new(nameof(MonoBinder), Namespaces.Aspid_MVVM);
     
     public static readonly AttributeText BinderLogAttribute =
         new("BinderLogAttribute", Namespaces.Aspid_MVVM);
@@ -159,5 +173,5 @@ public static class Classes
         new("CreateFromAttribute", Namespaces.Aspid_MVVM);
     
     public static readonly AttributeText AddComponentContextMenuAttribute =
-        new ("AddComponentContextMenuAttribute", Namespaces.Aspid_MVVM_UNITY);
+        new ("AddComponentContextMenuAttribute", Namespaces.Aspid_MVVM);
 }

--- a/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Descriptions/Namespaces.Aspid.cs
+++ b/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Descriptions/Namespaces.Aspid.cs
@@ -8,6 +8,5 @@ public static class Namespaces
     public static readonly NamespaceText Aspid = new(nameof(Aspid));
     
     public static readonly NamespaceText Aspid_MVVM = new("MVVM", Aspid);
-    public static readonly NamespaceText Aspid_MVVM_UNITY = new("Unity", Aspid_MVVM);
     public static readonly NamespaceText Aspid_MVVM_Generated = new("Generated", Aspid_MVVM);
 }

--- a/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/Body/BinderFieldsBody.cs
+++ b/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/Body/BinderFieldsBody.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Aspid.Generators.Helper;
+using Aspid.Generators.Helper.Unity;
+using Aspid.MVVM.Generators.Generators.Views.Data;
+using Aspid.MVVM.Generators.Generators.Views.Helpers;
+using static Aspid.MVVM.Generators.Generators.Descriptions.Constants;
+using Classes = Aspid.MVVM.Generators.Generators.Descriptions.Classes;
+
+namespace Aspid.MVVM.Generators.Generators.Views.Body;
+
+public static class BinderFieldsBody
+{
+    public static void Generate(
+        string @namespace,
+        in ViewDataSpan data,
+        DeclarationText declaration,
+        in SourceProductionContext context)
+    {
+        var virtualFields = VirtualBinderFields.Collect(data);
+        if (virtualFields.Count is 0) return;
+
+        var code = new CodeWriter();
+        code.BeginClass(@namespace, declaration);
+
+        foreach (var info in virtualFields.Values)
+        {
+            var requireBinderArgs = string.Join(", ", info.RequireBinderTypes.Select(type => $"typeof({type})"));
+
+            code.AppendLine(GeneratedCodeViewAttribute);
+
+            if (info.HeaderGroup is not null)
+                code.AppendLine($"[{Classes.HeaderGroupAttribute}({EscapeStringLiteral(info.HeaderGroup)})]");
+
+            if (info.Header is not null)
+                code.AppendLine($"[{Classes.HeaderAttribute}({EscapeStringLiteral(info.Header)})]");
+
+            code.AppendLine($"[{Classes.RequireBinderAttribute}({requireBinderArgs})]")
+                .AppendLine($"[{UnityClasses.SerializeField}] private {Classes.MonoBinder}[] {info.FieldName};")
+                .AppendLine();
+        }
+
+        code.EndClass(@namespace);
+        context.AddSource(declaration.GetFileName(@namespace, "BinderFields"), code.GetSourceText());
+    }
+
+    private static string EscapeStringLiteral(string value) =>
+        $"\"{value.Replace("\\", "\\\\").Replace("\"", "\\\"")}\"";
+}

--- a/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/Body/GenericInitializeView.cs
+++ b/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/Body/GenericInitializeView.cs
@@ -4,6 +4,7 @@ using Aspid.Generators.Helper;
 using System.Collections.Generic;
 using Aspid.MVVM.Generators.Generators.Views.Data;
 using Aspid.MVVM.Generators.Generators.Descriptions;
+using Aspid.MVVM.Generators.Generators.Views.Helpers;
 using Aspid.MVVM.Generators.Generators.ViewModels.Factories;
 using Aspid.MVVM.Generators.Generators.ViewModels.Data.Infos;
 using Aspid.MVVM.Generators.Generators.Views.Body.Extensions;
@@ -120,6 +121,13 @@ public static class GenericInitializeView
                 {
                     code.AppendBindSafely(member);
                 }
+            }
+
+            var virtualFields = VirtualBinderFields.Collect(data);
+            foreach (var info in virtualFields.Values)
+            {
+                if (bindableMembers.TryGetValue(info.Id.SourceValue, out var bindableMember))
+                    code.AppendLine($"{info.FieldName}.BindSafely(viewModel.{bindableMember.Bindable.PropertyName}, this, {info.Id.Value});");
             }
         }
         else

--- a/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/Body/InitializeBody.cs
+++ b/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/Body/InitializeBody.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Aspid.Generators.Helper;
 using Aspid.MVVM.Generators.Generators.Views.Data;
 using Aspid.MVVM.Generators.Generators.Descriptions;
+using Aspid.MVVM.Generators.Generators.Views.Helpers;
 using Aspid.MVVM.Generators.Generators.Views.Data.Members;
 using Aspid.MVVM.Generators.Generators.Views.Body.Extensions;
 using static Aspid.Generators.Helper.Classes;
@@ -233,7 +234,11 @@ public static class InitializeBody
 
         foreach (var member in data.Members)
             code.AppendBindSafely(member);
-        
+
+        var virtualFields = VirtualBinderFields.Collect(data);
+        foreach (var info in virtualFields.Values)
+            code.AppendLine($"{info.FieldName}.BindSafely(viewModel.FindBindableMember(new({info.Id.Value})), this, {info.Id.Value});");
+
         return code.AppendLine()
             .AppendLine("OnInitializedInternal(viewModel);")
             .AppendLine("__isInitializing = false;")
@@ -267,6 +272,10 @@ public static class InitializeBody
                 code.AppendLine($"{member.Name}.UnbindSafely(this, {member.Id});");
             }
         }
+
+        var virtualFields = VirtualBinderFields.Collect(data);
+        foreach (var info in virtualFields.Values)
+            code.AppendLine($"{info.FieldName}.UnbindSafely(this, {info.Id.Value});");
 
         code.AppendLine()
             .AppendLine("OnDeinitializedInternal();")

--- a/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/Data/ViewData.cs
+++ b/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/Data/ViewData.cs
@@ -7,14 +7,16 @@ namespace Aspid.MVVM.Generators.Generators.Views.Data;
 
 public readonly struct ViewData(
     INamedTypeSymbol symbol,
-    Inheritor inheritor, 
+    Inheritor inheritor,
     TypeDeclarationSyntax declaration,
     ImmutableArray<BinderMember> members,
-    ImmutableArray<GenericViewData> genericViews)
+    ImmutableArray<GenericViewData> genericViews,
+    ImmutableArray<string> inheritedDeclaredIds)
 {
-    public readonly INamedTypeSymbol Symbol = symbol; 
+    public readonly INamedTypeSymbol Symbol = symbol;
     public readonly Inheritor Inheritor = inheritor;
     public readonly ImmutableArray<BinderMember> Members = members;
     public readonly TypeDeclarationSyntax Declaration = declaration;
     public readonly ImmutableArray<GenericViewData> GenericViews = genericViews;
+    public readonly ImmutableArray<string> InheritedDeclaredIds = inheritedDeclaredIds;
 }

--- a/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/Data/ViewDataSpan.cs
+++ b/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/Data/ViewDataSpan.cs
@@ -14,6 +14,7 @@ public readonly ref struct ViewDataSpan(ViewData viewData)
     public readonly ReadOnlySpan<BinderMember> Members = viewData.Members.AsSpan();
     public readonly BinderMembersCollectionSpanByType MembersByType = new(viewData.Members);
     public readonly ReadOnlySpan<GenericViewData> GenericViews = viewData.GenericViews.AsSpan();
+    public readonly ReadOnlySpan<string> InheritedDeclaredIds = viewData.InheritedDeclaredIds.AsSpan();
 
     public bool IsInstantiateBinders => MembersByType.AsBinders.Length + MembersByType.PropertyBinders.Length > 0;
 }

--- a/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/Factories/BinderMembersFactory.cs
+++ b/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/Factories/BinderMembersFactory.cs
@@ -12,6 +12,21 @@ namespace Aspid.MVVM.Generators.Generators.Views.Factories;
 
 public static class BinderMembersFactory
 {
+    public static ImmutableArray<string> CollectInheritedIds(INamedTypeSymbol symbol, SemanticModel semanticModel)
+    {
+        var ids = ImmutableArray.CreateBuilder<string>();
+
+        for (var baseType = symbol.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            if (!baseType.HasAnyAttributeInSelf(Classes.ViewAttribute)) continue;
+
+            foreach (var member in Create(baseType, semanticModel))
+                ids.Add(member.Id.SourceValue);
+        }
+
+        return ids.ToImmutable();
+    }
+
     public static ImmutableArray<BinderMember> Create(INamedTypeSymbol symbolClass, SemanticModel semanticModel)
     {
         var binderMembers = new List<BinderMember>();

--- a/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/Helpers/VirtualBinderFields.cs
+++ b/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/Helpers/VirtualBinderFields.cs
@@ -1,0 +1,177 @@
+using Microsoft.CodeAnalysis;
+using System.Collections.Generic;
+using Aspid.Generators.Helper;
+using Aspid.Generators.Helper.Unity;
+using Aspid.MVVM.Generators.Generators.Ids.Data;
+using Aspid.MVVM.Generators.Generators.Views.Data;
+using Aspid.MVVM.Generators.Generators.ViewModels.Factories;
+using Aspid.MVVM.Generators.Generators.ViewModels.Data.Infos;
+using Classes = Aspid.MVVM.Generators.Generators.Descriptions.Classes;
+using SymbolExtensions = Aspid.MVVM.Generators.Helpers.SymbolExtensions;
+
+namespace Aspid.MVVM.Generators.Generators.Views.Helpers;
+
+public static class VirtualBinderFields
+{
+    public static Dictionary<string, Info> Collect(in ViewDataSpan data)
+    {
+        var result = new Dictionary<string, Info>();
+        if (data.GenericViews.Length == 0) return result;
+        if (!IsAutoBinderFieldsEnabled(data.Symbol)) return result;
+        if (InheritsFromScriptableObject(data.Symbol)) return result;
+
+        var declared = new HashSet<string>();
+        foreach (var member in data.Members)
+            declared.Add(member.Id.SourceValue);
+        foreach (var id in data.InheritedDeclaredIds)
+            declared.Add(id);
+
+        foreach (var genericView in data.GenericViews)
+        {
+            if (genericView.Type.TypeKind is TypeKind.Interface) continue;
+
+            for (var viewModelType = genericView.Type; viewModelType is not null; viewModelType = viewModelType.BaseType)
+            {
+                CollectFromType(viewModelType, data, declared, result);
+            }
+        }
+
+        return result;
+    }
+
+    private static void CollectFromType(
+        ITypeSymbol viewModelType,
+        in ViewDataSpan data,
+        HashSet<string> declared,
+        Dictionary<string, Info> result)
+    {
+        var bindableMembers = BindableMembersFactory.Create(viewModelType, data.Declaration, out _);
+        if (bindableMembers.Length == 0) return;
+
+        var membersBySymbol = new Dictionary<ISymbol, List<IBindableMemberInfo>>(SymbolEqualityComparer.Default);
+        foreach (var bindable in bindableMembers)
+        {
+            if (!membersBySymbol.TryGetValue(bindable.Member, out var list))
+            {
+                list = [];
+                membersBySymbol[bindable.Member] = list;
+            }
+            
+            list.Add(bindable);
+        }
+
+        string? activeGroup = null;
+
+        foreach (var symbol in viewModelType.GetMembers())
+        {
+            var groupStart = GetAttributeStringArgument(symbol, Classes.HeaderGroupStartAttribute);
+            var groupName = GetAttributeStringArgument(symbol, Classes.HeaderGroupAttribute);
+            var groupEnd = HasAttribute(symbol, Classes.HeaderGroupEndAttribute);
+
+            if (groupStart is not null) activeGroup = groupStart;
+            else if (groupName is not null) activeGroup = groupName;
+
+            if (membersBySymbol.TryGetValue(symbol, out var bindablesForSymbol))
+            {
+                foreach (var bindableMember in bindablesForSymbol)
+                {
+                    var sourceValue = bindableMember.Id.SourceValue;
+                    if (declared.Contains(sourceValue)) continue;
+
+                    if (!result.TryGetValue(sourceValue, out var info))
+                    {
+                        info = new Info(bindableMember.Id, SymbolExtensions.GetFieldName(sourceValue, "_"));
+                        result[sourceValue] = info;
+                    }
+
+                    var requireType = StripNullable(bindableMember.Type);
+                    if (!info.RequireBinderTypes.Contains(requireType))
+                        info.RequireBinderTypes.Add(requireType);
+
+                    if (bindableMember is not BindableCommandInfo)
+                        info.Header ??= GetAttributeStringArgument(symbol, Classes.HeaderAttribute);
+
+                    if (activeGroup is not null)
+                        info.HeaderGroup ??= activeGroup;
+
+                    if (groupEnd && !info.HeaderGroupEnd)
+                        info.HeaderGroupEnd = true;
+                }
+            }
+
+            if (groupEnd) activeGroup = null;
+        }
+    }
+
+    private static bool IsAutoBinderFieldsEnabled(INamedTypeSymbol viewSymbol)
+    {
+        foreach (var attribute in viewSymbol.GetAttributes())
+        {
+            if (attribute.AttributeClass?.ToDisplayString() != Classes.ViewAttribute.FullName) continue;
+
+            foreach (var named in attribute.NamedArguments)
+            {
+                if (named.Key != "AutoBinderFields") continue;
+                if (named.Value.Value is bool enabled) return enabled;
+            }
+
+            return true;
+        }
+
+        return true;
+    }
+
+    private static bool InheritsFromScriptableObject(INamedTypeSymbol viewSymbol)
+    {
+        var scriptableObjectFullName = UnityClasses.ScriptableObject.FullName;
+
+        for (var type = viewSymbol.BaseType; type is not null; type = type.BaseType)
+        {
+            if (type.ToDisplayString() == scriptableObjectFullName) return true;
+        }
+
+        return false;
+    }
+
+    private static string? GetAttributeStringArgument(ISymbol symbol, AttributeText attributeText)
+    {
+        if (symbol.TryGetAnyAttributeInSelf(out var attribute, attributeText))
+        {
+            if (attribute.ConstructorArguments.Length is 0) return null;
+            
+            var value = attribute.ConstructorArguments[0].Value as string;
+            if (!string.IsNullOrWhiteSpace(value)) return value;
+        }
+
+        return null;
+    }
+
+    private static bool HasAttribute(ISymbol symbol, string attributeFullName)
+    {
+        foreach (var attribute in symbol.GetAttributes())
+        {
+            if (attribute.AttributeClass?.ToDisplayString() == attributeFullName) 
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string StripNullable(string type) =>
+        type.EndsWith("?") ? type.Substring(0, type.Length - 1) : type;
+    
+    public sealed class Info(IdData id, string fieldName)
+    {
+        public IdData Id { get; } = id;
+
+        public string FieldName { get; } = fieldName;
+
+        public List<string> RequireBinderTypes { get; } = [];
+
+        public string? Header { get; set; }
+        
+        public string? HeaderGroup { get; set; }
+        
+        public bool HeaderGroupEnd { get; set; }
+    }
+}

--- a/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/ViewGenerator.Find.cs
+++ b/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/ViewGenerator.Find.cs
@@ -25,11 +25,12 @@ public partial class ViewGenerator
             : Inheritor.None;
         
         var members = BinderMembersFactory.Create(symbol, context.SemanticModel);
+        var inheritedDeclaredIds = BinderMembersFactory.CollectInheritedIds(symbol, context.SemanticModel);
 
         Debug.Assert(context.TargetNode is TypeDeclarationSyntax);
         var candidate = Unsafe.As<TypeDeclarationSyntax>(context.TargetNode);
 
-        return new ViewData(symbol, inheritor, candidate, members, GetGenericViews(symbol));
+        return new ViewData(symbol, inheritor, candidate, members, GetGenericViews(symbol), inheritedDeclaredIds);
     }
 
     private static ImmutableArray<GenericViewData> GetGenericViews(INamedTypeSymbol symbol)

--- a/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/ViewGenerator.Generate.cs
+++ b/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/Views/ViewGenerator.Generate.cs
@@ -17,6 +17,7 @@ public partial class ViewGenerator
         
         InitializeBody.Generate(@namespace, dataSpan, declarationText, context);
         BinderCachedBody.Generate(@namespace, dataSpan, declarationText, context);
+        BinderFieldsBody.Generate(@namespace, dataSpan, declarationText, context);
         GenericInitializeView.Generate(@namespace, dataSpan, declarationText, context);
     }
 }


### PR DESCRIPTION
## Summary

- New `VirtualBinderFields` collector scans bindable members on the View's `[GenericView]` ViewModel types and, for every member not already declared as a binder field on the View, schedules a virtual `_<name> : MonoBinder[]` slot. Opt out via `[View(AutoBinderFields = false)]` (defaults to `true`) or by deriving from `ScriptableObject`.
- New `BinderFieldsBody` writes the virtual slots into a `<View>.BinderFields.g.cs` partial: `[RequireBinder(typeof(...))]` + `[SerializeField] private MonoBinder[] _<name>;`, with optional `[Header]` / `[Aspid.MVVM.HeaderGroup]` carried over from the matching VM member so the inspector can render foldout groups.
- `ViewGenerator` / `BinderMembersFactory` / `ViewData` / `ViewDataSpan` / `InitializeBody` / `GenericInitializeView` updated to thread the virtual fields through the existing initialization pipeline; `Descriptions.Classes` registers the new `HeaderGroup*` attributes and points `MonoBinder` / `AddComponentContextMenuAttribute` at their actual `Aspid.MVVM` namespace.

## Notes for review

- Runtime side of this work (the `HeaderGroupAttribute` / `HeaderGroupStartAttribute` / `HeaderGroupEndAttribute` types this generator now references, plus the `[View(AutoBinderFields = ...)]` property and the inspector `HeaderGroupRouter`) lives in the main repo PR — link will be added once that PR is open.
- The DLL consumed by the Unity project is rebuilt and committed in the main repo PR, not here.


## Linked issues

Refs VPDPersonal/Aspid.MVVM#75
Main repo PR: VPDPersonal/Aspid.MVVM#74
