### PR TITLE
fix(build): repoint the sample glob and the DLL copy at the package layout

### DIFF
--- a/Aspid.MVVM.Generators/Aspid.MVVM.Generators.Sample/Aspid.MVVM.Generators.Sample.csproj
+++ b/Aspid.MVVM.Generators/Aspid.MVVM.Generators.Sample/Aspid.MVVM.Generators.Sample.csproj
@@ -15,12 +15,12 @@
     </ItemGroup>
 
     <!--
-        Compile the entire Unity-independent core (Assets/Aspid/MVVM/Source) so the
+        Compile the entire Unity-independent core (Packages/tech.aspid.mvvm/Source) so the
         source generator runs over it. A recursive glob is used instead of an explicit
         file list so the project stays in sync as Source files are added/removed/renamed.
     -->
     <ItemGroup>
-        <Compile Include="..\..\..\Aspid.MVVM\Assets\Aspid\MVVM\Source\**\*.cs">
+        <Compile Include="..\..\..\Aspid.MVVM\Packages\tech.aspid.mvvm\Source\**\*.cs">
             <Link>Source\%(RecursiveDir)%(Filename)%(Extension)</Link>
         </Compile>
     </ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,7 +2,7 @@
 
     <Target Name="CopyToUnity" AfterTargets="Build" Condition="'$(IsRoslynComponent)' == 'true'">
         <PropertyGroup>
-            <_UnityDestination>$(MSBuildThisFileDirectory)../Aspid.MVVM/Assets/Aspid/MVVM/</_UnityDestination>
+            <_UnityDestination>$(MSBuildThisFileDirectory)../Aspid.MVVM/Packages/tech.aspid.mvvm/</_UnityDestination>
         </PropertyGroup>
         <MakeDir Directories="$(_UnityDestination)" />
         <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(_UnityDestination)" SkipUnchangedFiles="true" />


### PR DESCRIPTION
## Summary

Two path fixes left over from the move to an embedded UPM package layout. Both failed *silently* — nothing pointed at them until the sample build was actually exercised.

- 🐛 **`Aspid.MVVM.Generators.Sample.csproj`** — the `Compile` glob still pointed at `Assets/Aspid/MVVM/Source`, but the Unity-independent core now lives in `Packages/tech.aspid.mvvm/Source`. A glob that matches nothing fails quietly, so the source generator no longer ran over the core at all, and the build stopped acting as the guard that keeps Unity-only API out of Unity-independent code.
- 🐛 **`Directory.Build.targets`** — `CopyToUnity` had the same stale prefix, and its `MakeDir` recreated `Assets/Aspid/MVVM/` on every build. The bare DLL dropped there was imported by Unity as a plain managed plugin — no `RoslynAnalyzer` label, reference validation on — so the Editor reported unresolved `Aspid.Generators.Helper` / `Aspid.Generators.Helper.Unity` references. Now the copy lands on `Packages/tech.aspid.mvvm/`, where the committed DLL and its `.meta` already live.

## Verification

- ✅ `dotnet build` on `Aspid.MVVM.Generators.Sample` compiles the whole core — **0 errors**.
- ✅ `dotnet build` on the generator refreshes `Packages/tech.aspid.mvvm/Aspid.MVVM.Generators.dll` in place and leaves no `Assets/Aspid/` behind.
- ✅ Live `6000.4.0f1` Editor: recompile `completed`, console clean — **0** errors *and* warnings.

<details>
<summary>🇷🇺 Описание на русском</summary>

## Суть

Два устаревших пути, оставшихся после переезда на встроенный UPM-пакет. Оба ломались *молча* — проблему ничто не показывало, пока сборку sample-проекта реально не запустили.

- 🐛 **`Aspid.MVVM.Generators.Sample.csproj`** — glob `Compile` всё ещё указывал на `Assets/Aspid/MVVM/Source`, хотя Unity-независимое ядро теперь лежит в `Packages/tech.aspid.mvvm/Source`. Glob, который ничего не находит, падает беззвучно, поэтому генератор вообще перестал прогоняться по ядру, а сборка перестала работать защитой, не пускающей Unity-only API в Unity-независимый код.
- 🐛 **`Directory.Build.targets`** — у `CopyToUnity` был тот же устаревший префикс, а его `MakeDir` заново создавал `Assets/Aspid/MVVM/` при каждой сборке. Голую DLL оттуда Unity импортировала как обычный managed-плагин — без лейбла `RoslynAnalyzer`, с включённой валидацией ссылок — и редактор сообщал о неразрешённых ссылках `Aspid.Generators.Helper` / `Aspid.Generators.Helper.Unity`. Теперь копия кладётся в `Packages/tech.aspid.mvvm/`, где уже лежат закоммиченная DLL и её `.meta`.

## Проверка

- ✅ `dotnet build` для `Aspid.MVVM.Generators.Sample` компилирует всё ядро — **0 ошибок**.
- ✅ `dotnet build` генератора обновляет `Packages/tech.aspid.mvvm/Aspid.MVVM.Generators.dll` на месте и не оставляет после себя `Assets/Aspid/`.
- ✅ Живой редактор `6000.4.0f1`: recompile `completed`, консоль чистая — **0** ошибок *и* предупреждений.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEP1RQk78AYQgbKdvSPixk
