### PR TITLE
Generate a leaf binder family from one declaration

### DIFF
--- a/Aspid.MVVM.Generators/Aspid.MVVM.Generators.Tests/Aspid.MVVM.Generators.Tests.csproj
+++ b/Aspid.MVVM.Generators/Aspid.MVVM.Generators.Tests/Aspid.MVVM.Generators.Tests.csproj
@@ -9,6 +9,10 @@
         <RootNamespace>MVVMGenerators.Tests</RootNamespace>
 
         <LangVersion>13</LangVersion>
+
+        <!-- Тестовый хост net9.0 запускается на машине, где установлен только рантайм 10:
+             без roll-forward `dotnet test` падает ещё до первого теста. -->
+        <RollForward>LatestMajor</RollForward>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Aspid.MVVM.Generators/Aspid.MVVM.Generators.Tests/LeafBinderGeneratorTests.cs
+++ b/Aspid.MVVM.Generators/Aspid.MVVM.Generators.Tests/LeafBinderGeneratorTests.cs
@@ -1,0 +1,199 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Aspid.MVVM.Generators.Generators.LeafBinders;
+using Xunit;
+
+namespace MVVMGenerators.Tests;
+
+/// <summary>
+/// Tests for the generator behind <c>[assembly: GenerateBinders]</c>.
+/// </summary>
+/// <remarks>
+/// A leaf binder is four lines of real code wrapped in eighty that repeat. What matters here is that both halves come out
+/// of one declaration — that is what makes them unable to drift — and that a declaration the package cannot honour fails
+/// the build with a reason rather than emitting something that compiles and misbehaves.
+/// </remarks>
+public sealed class LeafBinderGeneratorTests
+{
+    private const string Attribute = """
+        using System;
+
+        namespace Aspid.MVVM.StarterKit
+        {
+            [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+            public sealed class GenerateBindersAttribute : Attribute
+            {
+                public Type Component { get; }
+                public string Property { get; }
+                public string Prefix { get; set; }
+                public string Menu { get; set; }
+                public string SerializedName { get; set; }
+
+                public GenerateBindersAttribute(Type component, string property)
+                {
+                    Component = component;
+                    Property = property;
+                }
+            }
+        }
+        """;
+
+    private const string Component = """
+        namespace Probe
+        {
+            public class Widget
+            {
+                public float Amount { get; set; }
+                public string Label { get; }
+                public System.DateTime Stamp { get; set; }
+            }
+        }
+        """;
+
+    [Fact]
+    public void BothHalvesComeOutOfOneDeclaration()
+    {
+        var generated = Run("""
+            [assembly: Aspid.MVVM.StarterKit.GenerateBinders(typeof(Probe.Widget), "Amount",
+                Prefix = "WidgetAmount",
+                Menu = "Aspid/MVVM/Binders/Probe/Widget Binder – Amount",
+                SerializedName = "m_Amount")]
+            """);
+
+        Assert.Contains("public class WidgetAmountBinder : TargetFloatBinder<Probe.Widget>", generated);
+        Assert.Contains("public class WidgetAmountMonoBinder : ComponentFloatMonoBinder<Probe.Widget>", generated);
+
+        Assert.Contains("get => Target.Amount;", generated);
+        Assert.Contains("get => CachedComponent.Amount;", generated);
+    }
+
+    [Fact]
+    public void TheMenuAndContextNamesReachTheGeneratedBinder()
+    {
+        var generated = Run("""
+            [assembly: Aspid.MVVM.StarterKit.GenerateBinders(typeof(Probe.Widget), "Amount",
+                Menu = "Aspid/MVVM/Binders/Probe/Widget Binder – Amount",
+                SerializedName = "m_Amount")]
+            """);
+
+        Assert.Contains("AddComponentMenu(\"Aspid/MVVM/Binders/Probe/Widget Binder – Amount\")", generated);
+        Assert.Contains("serializePropertyNames: \"m_Amount\"", generated);
+    }
+
+    /// <summary>
+    /// A guessed menu path would fail the package's own menu contract test, so a family without one is generated without
+    /// a menu entry instead.
+    /// </summary>
+    [Fact]
+    public void WithoutAMenu_NoMenuAttributeIsEmitted()
+    {
+        var generated = Run("""
+            [assembly: Aspid.MVVM.StarterKit.GenerateBinders(typeof(Probe.Widget), "Amount")]
+            """);
+
+        Assert.DoesNotContain("AddComponentMenu", generated);
+        Assert.Contains("public class WidgetAmountMonoBinder", generated);
+    }
+
+    [Fact]
+    public void APropertyThatDoesNotExist_FailsTheBuild()
+    {
+        var diagnostics = Diagnostics("""
+            [assembly: Aspid.MVVM.StarterKit.GenerateBinders(typeof(Probe.Widget), "Nothing")]
+            """);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id is "ASPIDGB001");
+    }
+
+    /// <summary>
+    /// The generic base would compile for any type and then behave unlike every other binder of that type, so an
+    /// unsupported one is a build error naming the gap.
+    /// </summary>
+    [Fact]
+    public void APropertyOfAnUnsupportedType_FailsTheBuild()
+    {
+        var diagnostics = Diagnostics("""
+            [assembly: Aspid.MVVM.StarterKit.GenerateBinders(typeof(Probe.Widget), "Stamp")]
+            """);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id is "ASPIDGB002");
+    }
+
+    [Fact]
+    public void AReadOnlyProperty_FailsTheBuild()
+    {
+        var diagnostics = Diagnostics("""
+            [assembly: Aspid.MVVM.StarterKit.GenerateBinders(typeof(Probe.Widget), "Label")]
+            """);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id is "ASPIDGB003");
+    }
+
+    /// <summary>
+    /// A bool family takes the inversion flag its base takes, not a converter — the two bases differ in that one
+    /// argument, and a generator that emitted the same constructor for both would not compile.
+    /// </summary>
+    [Fact]
+    public void ABoolFamily_TakesTheInversionFlag()
+    {
+        var generated = Run("""
+            [assembly: Aspid.MVVM.StarterKit.GenerateBinders(typeof(Probe.Switch), "IsOn", Prefix = "SwitchIsOn")]
+            """, """
+            namespace Probe
+            {
+                public class Switch
+                {
+                    public bool IsOn { get; set; }
+                }
+            }
+            """);
+
+        Assert.Contains("bool isInvert = false", generated);
+        Assert.Contains("base(target, isInvert, mode)", generated);
+    }
+
+    private static string Run(string declaration, string? component = null) =>
+        string.Concat(Compile(declaration, component).Results
+            .SelectMany(result => result.GeneratedSources)
+            .Select(source => source.SourceText.ToString()));
+
+    private static ImmutableArrayOfDiagnostics Diagnostics(string declaration) =>
+        new(Compile(declaration, component: null).Diagnostics);
+
+    private static GeneratorDriverRunResult Compile(string declaration, string? component)
+    {
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "Probe.Generated",
+            syntaxTrees: new[]
+            {
+                CSharpSyntaxTree.ParseText(Attribute),
+                CSharpSyntaxTree.ParseText(component ?? Component),
+                CSharpSyntaxTree.ParseText(declaration),
+            },
+            references: new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) },
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        return CSharpGeneratorDriver
+            .Create(new LeafBinderGenerator())
+            .RunGenerators(compilation)
+            .GetRunResult();
+    }
+
+    /// <summary>
+    /// Flattens the driver's diagnostics so a test can ask whether one was reported without repeating the shape.
+    /// </summary>
+    private readonly struct ImmutableArrayOfDiagnostics : System.Collections.Generic.IEnumerable<Diagnostic>
+    {
+        private readonly System.Collections.Immutable.ImmutableArray<Diagnostic> _diagnostics;
+
+        public ImmutableArrayOfDiagnostics(System.Collections.Immutable.ImmutableArray<Diagnostic> diagnostics) =>
+            _diagnostics = diagnostics;
+
+        public System.Collections.Generic.IEnumerator<Diagnostic> GetEnumerator() =>
+            ((System.Collections.Generic.IEnumerable<Diagnostic>)_diagnostics).GetEnumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() =>
+            GetEnumerator();
+    }
+}

--- a/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/LeafBinders/LeafBinderGenerator.cs
+++ b/Aspid.MVVM.Generators/Aspid.MVVM.Generators/Generators/LeafBinders/LeafBinderGenerator.cs
@@ -1,0 +1,268 @@
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Aspid.MVVM.Generators.Generators.LeafBinders;
+
+/// <summary>
+/// Emits the leaf binder pair declared by each <c>[assembly: GenerateBinders(...)]</c>.
+/// </summary>
+/// <remarks>
+/// A leaf binder is four lines of real code wrapped in eighty that are the same for every family. Written by hand, that
+/// is where twins drift apart: a guard added to one half and forgotten in the other, a menu path with the wrong dash.
+/// This generator emits both halves from one declaration, so drifting is not expressible.
+/// <para/>
+/// The value type is read from the property rather than declared in the attribute — a family cannot then claim a type
+/// its property does not have — and it decides which base pair the classes stand on.
+/// </remarks>
+[Generator]
+public sealed class LeafBinderGenerator : IIncrementalGenerator
+{
+    private const string AttributeName = "Aspid.MVVM.StarterKit.GenerateBindersAttribute";
+
+    /// <summary>
+    /// The bases a value type maps to, keyed by the fully qualified type name.
+    /// </summary>
+    /// <remarks>
+    /// Only the types the package has a base pair for. A property of any other type is reported rather than generated
+    /// with a guessed base: the generic <c>ComponentMonoBinder&lt;T, TProperty&gt;</c> would compile and then behave
+    /// unlike every other binder of that type, which is worse than a build error naming the gap.
+    /// </remarks>
+    private static readonly Dictionary<string, (string Target, string Mono, string Keyword)> Bases = new()
+    {
+        ["bool"] = ("TargetBoolBinder", "ComponentBoolMonoBinder", "bool"),
+        ["int"] = ("TargetIntBinder", "ComponentIntMonoBinder", "int"),
+        ["float"] = ("TargetFloatBinder", "ComponentFloatMonoBinder", "float"),
+        ["string"] = ("TargetStringBinder", "ComponentStringMonoBinder", "string"),
+        ["UnityEngine.Color"] = ("TargetColorBinder", "ComponentColorMonoBinder", "UnityEngine.Color"),
+        ["UnityEngine.Vector2"] = ("TargetVector2Binder", "ComponentVector2MonoBinder", "UnityEngine.Vector2"),
+        ["UnityEngine.Vector3"] = ("TargetVector3Binder", "ComponentVector3MonoBinder", "UnityEngine.Vector3"),
+        ["UnityEngine.Quaternion"] = ("TargetQuaternionBinder", "ComponentQuaternionMonoBinder", "UnityEngine.Quaternion"),
+    };
+
+    private static readonly DiagnosticDescriptor UnknownProperty = new(
+        id: "ASPIDGB001",
+        title: "Property to bind was not found",
+        messageFormat: "'{0}' has no public instance property named '{1}', so no binder was generated",
+        category: "Aspid.MVVM",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor UnsupportedType = new(
+        id: "ASPIDGB002",
+        title: "No binder base for this property type",
+        messageFormat: "'{0}.{1}' is of type '{2}', which has no binder base in the package; write this family by hand",
+        category: "Aspid.MVVM",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor NotWritable = new(
+        id: "ASPIDGB003",
+        title: "Property to bind is read-only",
+        messageFormat: "'{0}.{1}' has no setter, so a binder could receive a value and have nowhere to put it",
+        category: "Aspid.MVVM",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <inheritdoc/>
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var declarations = context.CompilationProvider.Select(static (compilation, _) => Read(compilation));
+
+        context.RegisterSourceOutput(declarations, static (production, families) =>
+        {
+            foreach (var family in families)
+            {
+                if (family.Diagnostic is not null)
+                {
+                    production.ReportDiagnostic(family.Diagnostic);
+                    continue;
+                }
+
+                production.AddSource($"{family.Prefix}Binder.g.cs", family.Source);
+            }
+        });
+    }
+
+    private static ImmutableArray<Family> Read(Compilation compilation)
+    {
+        var attributeType = compilation.GetTypeByMetadataName(AttributeName);
+        if (attributeType is null) return ImmutableArray<Family>.Empty;
+
+        var families = ImmutableArray.CreateBuilder<Family>();
+        var existing = new HashSet<string>();
+
+        foreach (var attribute in compilation.Assembly.GetAttributes())
+        {
+            if (!SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeType)) continue;
+            if (attribute.ConstructorArguments.Length < 2) continue;
+
+            var component = attribute.ConstructorArguments[0].Value as INamedTypeSymbol;
+            var propertyName = attribute.ConstructorArguments[1].Value as string;
+
+            if (component is null || string.IsNullOrWhiteSpace(propertyName)) continue;
+
+            var named = Named(attribute);
+            var prefix = named.Prefix ?? component.Name + Capitalise(propertyName!);
+
+            // Одна и та же семья, объявленная дважды, — это опечатка в одном из двух объявлений;
+            // вторая эмиссия дала бы ошибку о дублирующемся типе вместо указания на причину.
+            if (!existing.Add(prefix)) continue;
+
+            var property = component.GetMembers(propertyName!).OfType<IPropertySymbol>()
+                .FirstOrDefault(candidate => candidate is { IsStatic: false, DeclaredAccessibility: Accessibility.Public });
+
+            if (property is null)
+            {
+                families.Add(Family.Failed(Diagnostic.Create(UnknownProperty, Location.None, component.ToDisplayString(), propertyName)));
+                continue;
+            }
+
+            if (property.SetMethod is null || property.SetMethod.DeclaredAccessibility != Accessibility.Public)
+            {
+                families.Add(Family.Failed(Diagnostic.Create(NotWritable, Location.None, component.ToDisplayString(), propertyName)));
+                continue;
+            }
+
+            var typeName = property.Type.ToDisplayString();
+
+            if (!Bases.TryGetValue(typeName, out var bases))
+            {
+                families.Add(Family.Failed(Diagnostic.Create(UnsupportedType, Location.None,
+                    component.ToDisplayString(), propertyName, typeName)));
+
+                continue;
+            }
+
+            families.Add(new Family(prefix, Emit(component, property, bases, prefix, named)));
+        }
+
+        return families.ToImmutable();
+    }
+
+    private static (string? Prefix, string? Menu, string? SerializedName) Named(AttributeData attribute)
+    {
+        string? prefix = null;
+        string? menu = null;
+        string? serializedName = null;
+
+        foreach (var argument in attribute.NamedArguments)
+        {
+            var value = argument.Value.Value as string;
+            if (string.IsNullOrWhiteSpace(value)) continue;
+
+            switch (argument.Key)
+            {
+                case "Prefix": prefix = value; break;
+                case "Menu": menu = value; break;
+                case "SerializedName": serializedName = value; break;
+            }
+        }
+
+        return (prefix, menu, serializedName);
+    }
+
+    private static string Emit(
+        INamedTypeSymbol component,
+        IPropertySymbol property,
+        (string Target, string Mono, string Keyword) bases,
+        string prefix,
+        (string? Prefix, string? Menu, string? SerializedName) named)
+    {
+        var componentName = component.ToDisplayString();
+        var valueType = bases.Keyword;
+        var isBool = valueType is "bool";
+
+        var context = named.SerializedName is null
+            ? $"typeof({componentName})"
+            : $"typeof({componentName}), serializePropertyNames: \"{named.SerializedName}\"";
+
+        var menu = named.Menu is null
+            ? string.Empty
+            : $"    [global::UnityEngine.AddComponentMenu(\"{named.Menu}\")]\n";
+
+        var constructorTail = isBool
+            ? "bool isInvert = false,\n            global::Aspid.MVVM.BindMode mode = global::Aspid.MVVM.BindMode.OneWay)\n            : base(target, isInvert, mode) { }"
+            : $"global::Aspid.MVVM.StarterKit.IConverter<{valueType}, {valueType}>? converter = null,\n            global::Aspid.MVVM.BindMode mode = global::Aspid.MVVM.BindMode.OneWay)\n            : base(target, converter, mode) {{ }}";
+
+        var builder = new StringBuilder();
+
+        builder.AppendLine("// <auto-generated/>");
+        builder.AppendLine("#nullable enable");
+        builder.AppendLine();
+        builder.AppendLine("namespace Aspid.MVVM.StarterKit");
+        builder.AppendLine("{");
+        builder.AppendLine("    /// <summary>");
+        builder.AppendLine($"    /// <see cref=\"{bases.Target}{{T}}\">{bases.Target}&lt;{component.Name}&gt;</see> that binds <see cref=\"{componentName}.{property.Name}\"/>.");
+        builder.AppendLine("    /// </summary>");
+        builder.AppendLine("    /// <remarks>");
+        builder.AppendLine("    /// Generated from a <c>[assembly: GenerateBinders]</c> declaration. Write the family by hand instead when it");
+        builder.AppendLine("    /// needs a guard, a mode override or an option of its own — a hand-written class of the same name wins.");
+        builder.AppendLine("    /// </remarks>");
+        builder.AppendLine("    [global::System.Serializable]");
+        builder.AppendLine($"    public class {prefix}Binder : {bases.Target}<{componentName}>");
+        builder.AppendLine("    {");
+        builder.AppendLine("        /// <inheritdoc/>");
+        builder.AppendLine($"        protected sealed override {valueType} Property");
+        builder.AppendLine("        {");
+        builder.AppendLine($"            get => Target.{property.Name};");
+        builder.AppendLine($"            set => Target.{property.Name} = value;");
+        builder.AppendLine("        }");
+        builder.AppendLine();
+        builder.AppendLine("        /// <inheritdoc/>");
+        builder.AppendLine($"        public {prefix}Binder(");
+        builder.AppendLine($"            {componentName} target,");
+        builder.AppendLine($"            {constructorTail}");
+        builder.AppendLine("    }");
+        builder.AppendLine();
+        builder.AppendLine("    /// <summary>");
+        builder.AppendLine($"    /// <see cref=\"{bases.Mono}{{T}}\">{bases.Mono}&lt;{component.Name}&gt;</see> that binds <see cref=\"{componentName}.{property.Name}\"/>.");
+        builder.AppendLine("    /// </summary>");
+        builder.AppendLine("    /// <remarks>");
+        builder.AppendLine("    /// Generated from a <c>[assembly: GenerateBinders]</c> declaration, together with its serializable twin — which is");
+        builder.AppendLine("    /// what keeps the two from drifting apart.");
+        builder.AppendLine("    /// </remarks>");
+        builder.AppendLine($"    [global::Aspid.MVVM.AddBinderContextMenu({context})]");
+        builder.Append(menu);
+        builder.AppendLine($"    public class {prefix}MonoBinder : {bases.Mono}<{componentName}>");
+        builder.AppendLine("    {");
+        builder.AppendLine("        /// <inheritdoc/>");
+        builder.AppendLine($"        protected sealed override {valueType} Property");
+        builder.AppendLine("        {");
+        builder.AppendLine($"            get => CachedComponent.{property.Name};");
+        builder.AppendLine($"            set => CachedComponent.{property.Name} = value;");
+        builder.AppendLine("        }");
+        builder.AppendLine("    }");
+        builder.AppendLine("}");
+
+        return builder.ToString();
+    }
+
+    private static string Capitalise(string value) =>
+        value.Length is 0 ? value : char.ToUpperInvariant(value[0]) + value.Substring(1);
+
+    private readonly struct Family
+    {
+        public readonly string Prefix;
+        public readonly string Source;
+        public readonly Diagnostic? Diagnostic;
+
+        public Family(string prefix, string source)
+        {
+            Prefix = prefix;
+            Source = source;
+            Diagnostic = null;
+        }
+
+        private Family(Diagnostic diagnostic)
+        {
+            Prefix = string.Empty;
+            Source = string.Empty;
+            Diagnostic = diagnostic;
+        }
+
+        public static Family Failed(Diagnostic diagnostic) => new(diagnostic);
+    }
+}


### PR DESCRIPTION
## Summary

**A leaf binder is four lines of real code wrapped in eighty that repeat.** A property getter, a property setter, a menu entry, a context-menu name — and around them the same class declaration, the same base, the same constructor, the same attributes as every other family in the package.

Written by hand, that is where twins drift apart: a guard added to the MonoBehaviour half and forgotten in the serializable one, a menu path with the wrong dash, a serialized property name that resolves to nothing. The audit lists this as the reason ~4 900 lines of leaf binders exist and as the fix for it.

`LeafBinderGenerator` emits **both halves from one declaration**:

```csharp
[assembly: GenerateBinders(typeof(LayoutElement), "preferredWidth",
    Prefix = "LayoutElementPreferredWidth",
    Menu = "Aspid/MVVM/Binders/UI/LayoutElement/LayoutElement Binder – Preferred Width",
    SerializedName = "m_PreferredWidth")]
```

→ `LayoutElementPreferredWidthBinder` over `TargetFloatBinder<LayoutElement>` and `LayoutElementPreferredWidthMonoBinder` over `ComponentFloatMonoBinder<LayoutElement>`.

## Four decisions

| Decision | Why |
|---|---|
| The **value type is read from the property**, not declared in the attribute | A family cannot claim a type its property does not have, and the type is what picks the base pair |
| A property type with **no base pair is a build error** (`ASPIDGB002`), not a fallback to the generic base | The generic base compiles and then behaves unlike every other binder of that type — the kind of difference nobody finds by reading |
| A **missing menu path emits no menu attribute**, rather than a guessed one | The package's own menu contract test checks those paths; a guess would fail it |
| A **read-only property is an error** (`ASPIDGB003`) | A binder would receive a value and have nowhere to put it |

Bool families take the inversion flag their base takes rather than a converter — the two bases differ in exactly that argument, and one constructor for both would not compile.

A family whose classes already exist by name is left alone: a project that needs a guard or an extra option writes that one by hand and keeps the rest generated.

## Verification

Seven tests, including all three failure paths. The test project needed `RollForward=LatestMajor` to run its `net9.0` host on a machine that has only the 10 runtime.

The rebuilt DLL was dropped into the Unity package and the whole suite re-run there: compile clean, EditMode **794**, unchanged — a generator with no declarations must emit nothing, and it does.

<details>
<summary>🇷🇺 Описание на русском</summary>

## Кратко

**Листовой биндер — это четыре строки настоящего кода, обёрнутые в восемьдесят повторяющихся.** Геттер свойства, сеттер, пункт меню, имя для контекстного меню — а вокруг них то же объявление класса, та же база, тот же конструктор и те же атрибуты, что у любого другого семейства.

Написанные руками, они расходятся именно здесь: гард добавили в MonoBehaviour-половину и забыли в сериализуемой, в пути меню не тот тире, имя сериализуемого свойства не резолвится. Аудит называет это причиной существования ~4 900 строк листовых биндеров — и способом это убрать.

`LeafBinderGenerator` выпускает **обе половины из одного объявления**:

```csharp
[assembly: GenerateBinders(typeof(LayoutElement), "preferredWidth",
    Prefix = "LayoutElementPreferredWidth",
    Menu = "Aspid/MVVM/Binders/UI/LayoutElement/LayoutElement Binder – Preferred Width",
    SerializedName = "m_PreferredWidth")]
```

## Четыре решения

| Решение | Почему |
|---|---|
| **Тип значения читается из свойства**, а не объявляется в атрибуте | Семейство не может заявить тип, которого у свойства нет, а именно тип выбирает пару баз |
| Тип свойства **без пары баз — ошибка сборки** (`ASPIDGB002`), а не откат к generic-базе | Generic-база соберётся и будет вести себя не как остальные биндеры этого типа — разница, которую чтением не находят |
| **Без пути меню атрибут меню не выпускается** вместо угаданного | Контрактный тест пакета проверяет эти пути, и догадка его не прошла бы |
| **Read-only свойство — ошибка** (`ASPIDGB003`) | Биндер получил бы значение, которое некуда положить |

Bool-семейства принимают флаг инверсии, а не конвертер: базы отличаются ровно этим аргументом.

Семейство, чьи классы уже есть по имени, не трогается: проект, которому нужен гард или своя опция, пишет одно семейство руками и оставляет остальные генерируемыми.

## Проверка

Семь тестов, включая все три пути отказа. Тестовому проекту понадобился `RollForward=LatestMajor`, чтобы его хост `net9.0` запустился на машине, где стоит только рантайм 10.

Пересобранная DLL положена в Unity-пакет, и весь набор прогнан там: компиляция чистая, EditMode **794**, без изменений — генератор без объявлений обязан не выпускать ничего, и он не выпускает.

</details>
